### PR TITLE
Install plugins 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,19 @@
+import fnmatch
+import os
+
 from setuptools import setup, find_packages
+
+
+def find_package_data_files(directory):
+    for root, dirs, files in os.walk(directory):
+        for basename in files:
+            if fnmatch.fnmatch(basename, "*"):
+                filename = os.path.join(root, basename)
+                yield filename.replace("cfstore/", "", 1)
+
+
+plugins = [f for f in find_package_data_files("cfstore/plugins")]
+package_data = plugins
 
 setup(
     name='cfstore',
@@ -33,4 +48,5 @@ setup(
             'cfmv=cfstore.cfmv:safe_cli'
         ],
     },
+    package_data={"cfstore": package_data},
 )


### PR DESCRIPTION
Changes to ensure that `cfstore/plugins` gets copied to the install directory, to prevent:

```python
from cfstore.cfin import safe_cli
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-2-9a0452d5bd5e> in <module>
----> 1 from cfstore.cfin import safe_cli

~/.local/lib/python3.9/site-packages/cfstore/cfin.py in <module>
      1 
----> 2 from cfstore.plugins.et_main import et_main
      3 from cfstore.plugins.posix import RemotePosix
      4 from cfstore.config import CFSconfig
      5 from pathlib import Path

ModuleNotFoundError: No module named 'cfstore.plugins'
```